### PR TITLE
開発ツール用の統合devcontainer featureを追加

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
         features:
           - color
           - hello
+          - tools
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -36,6 +37,7 @@ jobs:
         features:
           - color
           - hello
+          - tools
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,188 +1,120 @@
-# Dev Container Features: Self Authoring Template
+# Dev Container Features: Personal Development Tools
 
-> This repo provides a starting point and example for creating your own custom [dev container Features](https://containers.dev/implementors/features/), hosted for free on GitHub Container Registry.  The example in this repository follows the [dev container Feature distribution specification](https://containers.dev/implementors/features-distribution/).  
->
-> To provide feedback to the specification, please leave a comment [on spec issue #70](https://github.com/devcontainers/spec/issues/70). For more broad feedback regarding dev container Features, please see [spec issue #61](https://github.com/devcontainers/spec/issues/61).
+[devcontainers/images](https://github.com/devcontainers/images/tree/main/src/universal) の universal イメージをベースとした devcontainer に個人的に利用したいツールを追加するための [dev container Features](https://containers.dev/implementors/features/) リポジトリです。
 
-## Example Contents
+## Features
 
-This repository contains a _collection_ of two Features - `hello` and `color`. These Features serve as simple feature implementations.  Each sub-section below shows a sample `devcontainer.json` alongside example usage of the Feature.
+### `tools` - 開発ツールコレクション
 
-### `hello`
+ripgrep (rg)、ast-grep、semgrep の3つの開発ツールをまとめてインストールする Feature です。
 
-Running `hello` inside the built container will print the greeting provided to it via its `greeting` option.
+#### 使用例
 
 ```jsonc
 {
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
     "features": {
-        "ghcr.io/devcontainers/feature-starter/hello:1": {
+        "ghcr.io/to-hutohu/devcontainer-features/tools:1": {}
+    }
+}
+```
+
+#### オプション
+
+| オプション | 説明 | タイプ | デフォルト値 |
+|-----|-----|-----|-----|
+| installRg | ripgrep (rg) をインストール | boolean | true |
+| rgVersion | ripgrep のバージョン | string | latest |
+| installAstGrep | ast-grep をインストール | boolean | true |
+| astGrepVersion | ast-grep のバージョン | string | latest |
+| installSemgrep | semgrep をインストール | boolean | true |
+| semgrepVersion | semgrep のバージョン | string | latest |
+
+#### カスタマイズ例
+
+特定のツールのみインストール:
+```jsonc
+{
+    "features": {
+        "ghcr.io/to-hutohu/devcontainer-features/tools:1": {
+            "installRg": true,
+            "installAstGrep": false,
+            "installSemgrep": true
+        }
+    }
+}
+```
+
+特定のバージョンを指定:
+```jsonc
+{
+    "features": {
+        "ghcr.io/to-hutohu/devcontainer-features/tools:1": {
+            "rgVersion": "14.1.0",
+            "astGrepVersion": "0.12.0",
+            "semgrepVersion": "1.45.0"
+        }
+    }
+}
+```
+
+### `hello`
+
+挨拶メッセージを表示するサンプル Feature です。
+
+```jsonc
+{
+    "features": {
+        "ghcr.io/to-hutohu/devcontainer-features/hello:1": {
             "greeting": "Hello"
         }
     }
 }
 ```
 
-```bash
-$ hello
-
-Hello, user.
-```
-
 ### `color`
 
-Running `color` inside the built container will print your favorite color to standard out.
+お気に入りの色を表示するサンプル Feature です。
 
 ```jsonc
 {
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
-        "ghcr.io/devcontainers/feature-starter/color:1": {
+        "ghcr.io/to-hutohu/devcontainer-features/color:1": {
             "favorite": "green"
         }
     }
 }
 ```
 
-```bash
-$ color
+## インストールされるツール
 
-my favorite color is green
-```
+### ripgrep (rg)
+高速なファイル内容検索ツール。正規表現を使用してディレクトリを再帰的に検索します。
 
-## Repo and Feature Structure
+### ast-grep
+コード構造を理解して検索・リファクタリングを行うツール。構文木ベースの検索が可能です。`ast-grep` と `sg` の両コマンドが利用可能です。
 
-Similar to the [`devcontainers/features`](https://github.com/devcontainers/features) repo, this repository has a `src` folder.  Each Feature has its own sub-folder, containing at least a `devcontainer-feature.json` and an entrypoint script `install.sh`. 
+### semgrep
+バグ、コードの匂い、セキュリティ脆弱性を見つけるための静的解析ツール。
+
+## リポジトリ構造
 
 ```
 ├── src
+│   ├── tools
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── README.md
 │   ├── hello
 │   │   ├── devcontainer-feature.json
 │   │   └── install.sh
-│   ├── color
-│   │   ├── devcontainer-feature.json
-│   │   └── install.sh
-|   ├── ...
-│   │   ├── devcontainer-feature.json
-│   │   └── install.sh
-...
+│   └── color
+│       ├── devcontainer-feature.json
+│       └── install.sh
+└── test
+    └── ...
 ```
 
-An [implementing tool](https://containers.dev/supporting#tools) will composite [the documented dev container properties](https://containers.dev/implementors/features/#devcontainer-feature-json-properties) from the feature's `devcontainer-feature.json` file, and execute in the `install.sh` entrypoint script in the container during build time.  Implementing tools are also free to process attributes under the `customizations` property as desired.
+## ライセンス
 
-### Options
-
-All available options for a Feature should be declared in the `devcontainer-feature.json`.  The syntax for the `options` property can be found in the [devcontainer Feature json properties reference](https://containers.dev/implementors/features/#devcontainer-feature-json-properties).
-
-For example, the `color` feature provides an enum of three possible options (`red`, `gold`, `green`).  If no option is provided in a user's `devcontainer.json`, the value is set to "red".
-
-```jsonc
-{
-    // ...
-    "options": {
-        "favorite": {
-            "type": "string",
-            "enum": [
-                "red",
-                "gold",
-                "green"
-            ],
-            "default": "red",
-            "description": "Choose your favorite color."
-        }
-    }
-}
-```
-
-Options are exported as Feature-scoped environment variables.  The option name is captialized and sanitized according to [option resolution](https://containers.dev/implementors/features/#option-resolution).
-
-```bash
-#!/bin/bash
-
-echo "Activating feature 'color'"
-echo "The provided favorite color is: ${FAVORITE}"
-
-...
-```
-
-## Distributing Features
-
-### Versioning
-
-Features are individually versioned by the `version` attribute in a Feature's `devcontainer-feature.json`.  Features are versioned according to the semver specification. More details can be found in [the dev container Feature specification](https://containers.dev/implementors/features/#versioning).
-
-### Publishing
-
-> NOTE: The Distribution spec can be [found here](https://containers.dev/implementors/features-distribution/).  
->
-> While any registry [implementing the OCI Distribution spec](https://github.com/opencontainers/distribution-spec) can be used, this template will leverage GHCR (GitHub Container Registry) as the backing registry.
-
-Features are meant to be easily sharable units of dev container configuration and installation code.  
-
-This repo contains a **GitHub Action** [workflow](.github/workflows/release.yaml) that will publish each Feature to GHCR. 
-
-*Allow GitHub Actions to create and approve pull requests* should be enabled in the repository's `Settings > Actions > General > Workflow permissions` for auto generation of `src/<feature>/README.md` per Feature (which merges any existing `src/<feature>/NOTES.md`).
-
-By default, each Feature will be prefixed with the `<owner/<repo>` namespace.  For example, the two Features in this repository can be referenced in a `devcontainer.json` with:
-
-```
-ghcr.io/devcontainers/feature-starter/color:1
-ghcr.io/devcontainers/feature-starter/hello:1
-```
-
-The provided GitHub Action will also publish a third "metadata" package with just the namespace, eg: `ghcr.io/devcontainers/feature-starter`.  This contains information useful for tools aiding in Feature discovery.
-
-'`devcontainers/feature-starter`' is known as the feature collection namespace.
-
-### Marking Feature Public
-
-Note that by default, GHCR packages are marked as `private`.  To stay within the free tier, Features need to be marked as `public`.
-
-This can be done by navigating to the Feature's "package settings" page in GHCR, and setting the visibility to 'public`.  The URL may look something like:
-
-```
-https://github.com/users/<owner>/packages/container/<repo>%2F<featureName>/settings
-```
-
-<img width="669" alt="image" src="https://user-images.githubusercontent.com/23246594/185244705-232cf86a-bd05-43cb-9c25-07b45b3f4b04.png">
-
-### Adding Features to the Index
-
-If you'd like your Features to appear in our [public index](https://containers.dev/features) so that other community members can find them, you can do the following:
-
-* Go to [github.com/devcontainers/devcontainers.github.io](https://github.com/devcontainers/devcontainers.github.io)
-     * This is the GitHub repo backing the [containers.dev](https://containers.dev/) spec site
-* Open a PR to modify the [collection-index.yml](https://github.com/devcontainers/devcontainers.github.io/blob/gh-pages/_data/collection-index.yml) file
-
-This index is from where [supporting tools](https://containers.dev/supporting) like [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [GitHub Codespaces](https://github.com/features/codespaces) surface Features for their dev container creation UI.
-
-#### Using private Features in Codespaces
-
-For any Features hosted in GHCR that are kept private, the `GITHUB_TOKEN` access token in your environment will need to have `package:read` and `contents:read` for the associated repository.
-
-Many implementing tools use a broadly scoped access token and will work automatically.  GitHub Codespaces uses repo-scoped tokens, and therefore you'll need to add the permissions in `devcontainer.json`
-
-An example `devcontainer.json` can be found below.
-
-```jsonc
-{
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-    "features": {
-     "ghcr.io/my-org/private-features/hello:1": {
-            "greeting": "Hello"
-        }
-    },
-    "customizations": {
-        "codespaces": {
-            "repositories": {
-                "my-org/private-features": {
-                    "permissions": {
-                        "packages": "read",
-                        "contents": "read"
-                    }
-                }
-            }
-        }
-    }
-}
-```
+MIT

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -1,0 +1,61 @@
+# Development Tools (rg, ast-grep, semgrep)
+
+Collection of development tools: ripgrep (rg), ast-grep, and semgrep.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/to-hutohu/devcontainer-features/tools:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| installRg | Install ripgrep (rg) - a blazing fast search tool | boolean | true |
+| rgVersion | Version of ripgrep to install | string | latest |
+| installAstGrep | Install ast-grep - a fast and polyglot tool for code structural search | boolean | true |
+| astGrepVersion | Version of ast-grep to install | string | latest |
+| installSemgrep | Install semgrep - static analysis tool for finding bugs and security vulnerabilities | boolean | true |
+| semgrepVersion | Version of semgrep to install | string | latest |
+
+## Installed Tools
+
+### ripgrep (rg)
+A blazing fast search tool that recursively searches directories for a regex pattern.
+
+### ast-grep
+A fast and polyglot tool for code structural search, lint and rewriting. Both `ast-grep` and `sg` commands will be available.
+
+### semgrep
+Static analysis tool for finding bugs, code smells, and security vulnerabilities.
+
+## Customization Examples
+
+Install only specific tools:
+```json
+"features": {
+    "ghcr.io/to-hutohu/devcontainer-features/tools:1": {
+        "installRg": true,
+        "installAstGrep": false,
+        "installSemgrep": true
+    }
+}
+```
+
+Install specific versions:
+```json
+"features": {
+    "ghcr.io/to-hutohu/devcontainer-features/tools:1": {
+        "rgVersion": "14.1.0",
+        "astGrepVersion": "0.12.0",
+        "semgrepVersion": "1.45.0"
+    }
+}
+```
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/to-hutohu/devcontainer-features/blob/main/src/tools/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/tools/devcontainer-feature.json
+++ b/src/tools/devcontainer-feature.json
@@ -1,0 +1,58 @@
+{
+    "name": "Development Tools (rg, ast-grep, semgrep)",
+    "id": "tools",
+    "version": "1.0.0",
+    "description": "Collection of development tools: ripgrep (rg), ast-grep, and semgrep",
+    "documentationURL": "https://github.com/to-hutohu/devcontainer-features",
+    "options": {
+        "installRg": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install ripgrep (rg) - a blazing fast search tool"
+        },
+        "rgVersion": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "14.1.0",
+                "13.0.0"
+            ],
+            "default": "latest",
+            "description": "Version of ripgrep to install"
+        },
+        "installAstGrep": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install ast-grep - a fast and polyglot tool for code structural search"
+        },
+        "astGrepVersion": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "0.12.0",
+                "0.11.0"
+            ],
+            "default": "latest",
+            "description": "Version of ast-grep to install"
+        },
+        "installSemgrep": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install semgrep - static analysis tool for finding bugs and security vulnerabilities"
+        },
+        "semgrepVersion": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "1.45.0",
+                "1.44.0"
+            ],
+            "default": "latest",
+            "description": "Version of semgrep to install"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/python"
+    ]
+}

--- a/src/tools/install.sh
+++ b/src/tools/install.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo "Activating feature 'Development Tools'"
+set -x  # Enable debug mode
 
 # Options
 INSTALL_RG=${INSTALLRG:-true}
@@ -14,7 +15,7 @@ SEMGREP_VERSION=${SEMGREPVERSION:-latest}
 # Common functions
 apt_get_update()
 {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+    if [ -z "$(find /var/lib/apt/lists -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
         echo "Running apt-get update..."
         apt-get update -y
     fi
@@ -102,12 +103,14 @@ if [ "${INSTALL_SEMGREP}" = "true" ]; then
     echo "Installing semgrep ${SEMGREP_VERSION}..."
     
     # Install python3 and pip if not already installed
+    echo "Installing Python dependencies..."
     check_packages python3 python3-pip python3-venv
     
     # Create a virtual environment for semgrep to avoid conflicts
     python3 -m venv /opt/semgrep-env
     
     # Activate virtual environment and install semgrep
+    echo "Installing semgrep in virtual environment..."
     if [ "${SEMGREP_VERSION}" = "latest" ]; then
         /opt/semgrep-env/bin/pip install --upgrade pip
         /opt/semgrep-env/bin/pip install semgrep
@@ -123,4 +126,5 @@ if [ "${INSTALL_SEMGREP}" = "true" ]; then
     semgrep --version
 fi
 
+set +x  # Disable debug mode
 echo "Development tools installation completed!"

--- a/src/tools/install.sh
+++ b/src/tools/install.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+set -e
+
+echo "Activating feature 'Development Tools'"
+
+# Options
+INSTALL_RG=${INSTALLRG:-true}
+RG_VERSION=${RGVERSION:-latest}
+INSTALL_AST_GREP=${INSTALLASTGREP:-true}
+AST_GREP_VERSION=${ASTGREPVERSION:-latest}
+INSTALL_SEMGREP=${INSTALLSEMGREP:-true}
+SEMGREP_VERSION=${SEMGREPVERSION:-latest}
+
+# Common functions
+apt_get_update()
+{
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install common dependencies
+check_packages curl ca-certificates
+
+# Get architecture
+architecture="$(dpkg --print-architecture)"
+
+# Install ripgrep (rg)
+if [ "${INSTALL_RG}" = "true" ]; then
+    echo "Installing ripgrep ${RG_VERSION}..."
+    
+    case "${architecture}" in
+        amd64) rg_arch="x86_64" ;;
+        arm64) rg_arch="aarch64" ;;
+        armhf) rg_arch="arm" ;;
+        i386) rg_arch="i686" ;;
+        *) echo "Unsupported architecture for ripgrep: ${architecture}" && INSTALL_RG="false" ;;
+    esac
+    
+    if [ "${INSTALL_RG}" = "true" ]; then
+        if [ "${RG_VERSION}" = "latest" ]; then
+            rg_download_url="https://github.com/BurntSushi/ripgrep/releases/latest/download/ripgrep-${rg_arch}-unknown-linux-musl.tar.gz"
+        else
+            rg_download_url="https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-${rg_arch}-unknown-linux-musl.tar.gz"
+        fi
+        
+        curl -sL "${rg_download_url}" | tar xz -C /tmp
+        if [ "${RG_VERSION}" = "latest" ]; then
+            mv /tmp/ripgrep-*/rg /usr/local/bin/
+        else
+            mv /tmp/ripgrep-${RG_VERSION}-${rg_arch}-unknown-linux-musl/rg /usr/local/bin/
+        fi
+        chmod +x /usr/local/bin/rg
+        
+        echo "ripgrep has been installed!"
+        rg --version
+    fi
+fi
+
+# Install ast-grep
+if [ "${INSTALL_AST_GREP}" = "true" ]; then
+    echo "Installing ast-grep ${AST_GREP_VERSION}..."
+    
+    case "${architecture}" in
+        amd64) ast_arch="x86_64" ;;
+        arm64) ast_arch="aarch64" ;;
+        armhf) ast_arch="armv7" ;;
+        *) echo "Unsupported architecture for ast-grep: ${architecture}" && INSTALL_AST_GREP="false" ;;
+    esac
+    
+    if [ "${INSTALL_AST_GREP}" = "true" ]; then
+        if [ "${AST_GREP_VERSION}" = "latest" ]; then
+            ast_download_url="https://github.com/ast-grep/ast-grep/releases/latest/download/sg-${ast_arch}-unknown-linux-gnu.tar.gz"
+        else
+            ast_download_url="https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/sg-${ast_arch}-unknown-linux-gnu.tar.gz"
+        fi
+        
+        curl -sL "${ast_download_url}" | tar xz -C /tmp
+        mv /tmp/sg /usr/local/bin/ast-grep
+        chmod +x /usr/local/bin/ast-grep
+        
+        # Create sg symlink for convenience
+        ln -sf /usr/local/bin/ast-grep /usr/local/bin/sg
+        
+        echo "ast-grep has been installed!"
+        ast-grep --version
+    fi
+fi
+
+# Install semgrep
+if [ "${INSTALL_SEMGREP}" = "true" ]; then
+    echo "Installing semgrep ${SEMGREP_VERSION}..."
+    
+    # Install python3 and pip if not already installed
+    check_packages python3 python3-pip python3-venv
+    
+    # Create a virtual environment for semgrep to avoid conflicts
+    python3 -m venv /opt/semgrep-env
+    
+    # Activate virtual environment and install semgrep
+    if [ "${SEMGREP_VERSION}" = "latest" ]; then
+        /opt/semgrep-env/bin/pip install --upgrade pip
+        /opt/semgrep-env/bin/pip install semgrep
+    else
+        /opt/semgrep-env/bin/pip install --upgrade pip
+        /opt/semgrep-env/bin/pip install semgrep==${SEMGREP_VERSION}
+    fi
+    
+    # Create symlink to make semgrep available globally
+    ln -sf /opt/semgrep-env/bin/semgrep /usr/local/bin/semgrep
+    
+    echo "semgrep has been installed!"
+    semgrep --version
+fi
+
+echo "Development tools installation completed!"

--- a/test/_global/all_tools.sh
+++ b/test/_global/all_tools.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "rgがインストールされている" bash -c "which rg"
+check "rgのバージョン確認" bash -c "rg --version"
+
+check "ast-grepがインストールされている" bash -c "which ast-grep"
+check "sgコマンドが使える" bash -c "which sg"
+check "ast-grepのバージョン確認" bash -c "ast-grep --version"
+
+check "semgrepがインストールされている" bash -c "which semgrep"
+check "semgrepのバージョン確認" bash -c "semgrep --version"
+
+# Report result
+reportResults

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -9,5 +9,11 @@
                 "greeting": "Greetings"
             }
         }
+    },
+    "all_tools": {
+        "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+        "features": {
+            "tools": {}
+        }
     }
 }

--- a/test/tools/default.sh
+++ b/test/tools/default.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "rgがインストールされている" bash -c "which rg"
+check "rgのバージョン確認" bash -c "rg --version"
+
+check "ast-grepがインストールされている" bash -c "which ast-grep"
+check "sgコマンドが使える" bash -c "which sg"
+check "ast-grepのバージョン確認" bash -c "ast-grep --version"
+
+check "semgrepがインストールされている" bash -c "which semgrep"
+check "semgrepのバージョン確認" bash -c "semgrep --version"
+
+reportResults

--- a/test/tools/only_rg.sh
+++ b/test/tools/only_rg.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "rgがインストールされている" bash -c "which rg"
+check "rgのバージョン確認" bash -c "rg --version"
+
+check "ast-grepがインストールされていない" bash -c "! which ast-grep"
+check "sgコマンドが使えない" bash -c "! which sg"
+
+check "semgrepがインストールされていない" bash -c "! which semgrep"
+
+reportResults

--- a/test/tools/scenarios.json
+++ b/test/tools/scenarios.json
@@ -1,0 +1,28 @@
+{
+    "default": {
+        "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+        "features": {
+            "tools": {}
+        }
+    },
+    "only_rg": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "tools": {
+                "installRg": true,
+                "installAstGrep": false,
+                "installSemgrep": false
+            }
+        }
+    },
+    "specific_versions": {
+        "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+        "features": {
+            "tools": {
+                "rgVersion": "14.1.0",
+                "astGrepVersion": "0.12.0",
+                "semgrepVersion": "1.45.0"
+            }
+        }
+    }
+}

--- a/test/tools/specific_versions.sh
+++ b/test/tools/specific_versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "rgのバージョンが14.1.0" bash -c "rg --version | grep '14.1.0'"
+check "ast-grepのバージョンが0.12.0" bash -c "ast-grep --version | grep '0.12.0'"
+check "semgrepのバージョンが1.45.0" bash -c "semgrep --version | grep '1.45.0'"
+
+reportResults

--- a/test/tools/test.sh
+++ b/test/tools/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "rgがインストールされている" bash -c "which rg"
+check "rgのバージョン確認" bash -c "rg --version"
+
+check "ast-grepがインストールされている" bash -c "which ast-grep"
+check "sgコマンドが使える" bash -c "which sg"
+check "ast-grepのバージョン確認" bash -c "ast-grep --version"
+
+check "semgrepがインストールされている" bash -c "which semgrep"
+check "semgrepのバージョン確認" bash -c "semgrep --version"
+
+reportResults


### PR DESCRIPTION
## Summary
- ripgrep (rg)、ast-grep、semgrep の3つの開発ツールをまとめてインストールする統合 feature を追加
- 各ツールは個別にインストール有無を選択可能で、バージョン指定もサポート

## Test plan
- [x] 全ツールをインストールするテストケースを追加
- [x] 特定のツールのみインストールするテストケースを追加
- [x] バージョン指定のテストケースを追加

🤖 Generated with [Claude Code](https://claude.ai/code)